### PR TITLE
Forgot to add jQuery to the template page

### DIFF
--- a/tpl/page.jade
+++ b/tpl/page.jade
@@ -4,6 +4,7 @@ html
 		title= "Real time web chat"
 		script(src='/chat.js')
 		script(src='/socket.io/socket.io.js')
+		script(src='http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js')
 	body
 		#content(style='width: 500px; height: 300px; margin: 0 0 20px 0; border: solid 1px #999; overflow-y: scroll;')
 		.controls


### PR DESCRIPTION
As per comment in discussion thread (http://net.tutsplus.com/tutorials/javascript-ajax/real-time-chat-with-nodejs-socket-io-and-expressjs/), updated to fix jQuery undefined error effecting use of enter key
